### PR TITLE
Revert claim_one to yield before return

### DIFF
--- a/fastasyncpg/core.py
+++ b/fastasyncpg/core.py
@@ -736,9 +736,9 @@ async def claim_one(self:Table, status_col='status', pending='pending', complete
         tbl = txn.t[self.name]
         p.db = txn
         p.evt = await tbl.claim(where=f'"{status_col}"=$1', where_args=[pending], order_by=order_by)
-        if p.evt is None: return
         try: yield p
         except Exception as e: p.failed, p.exc, p.tb = True, e, traceback.format_exc()
+        if p.evt is None: return
         pk = self.pks[0]
         new = failed if p.failed else (None if p.retry else completed)
         stmt = f'UPDATE {self} SET "{status_col}"=$1 WHERE "{pk}"=$2'

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -997,7 +997,8 @@
     "        else:\n",
     "            pr,a = self.conn._params, self.conn._addr\n",
     "            u,h,d,p = pr.user, a[0], pr.database, a[1]\n",
-    "        return f\"postgresql://{u}@{h}:{p}/{d}\"\n"
+    "        return f\"postgresql://{u}@{h}:{p}/{d}\"\n",
+    ""
    ]
   },
   {
@@ -5092,9 +5093,9 @@
     "        tbl = txn.t[self.name]\n",
     "        p.db = txn\n",
     "        p.evt = await tbl.claim(where=f'\"{status_col}\"=$1', where_args=[pending], order_by=order_by)\n",
-    "        if p.evt is None: return\n",
     "        try: yield p\n",
     "        except Exception as e: p.failed, p.exc, p.tb = True, e, traceback.format_exc()\n",
+    "        if p.evt is None: return\n",
     "        pk = self.pks[0]\n",
     "        new = failed if p.failed else (None if p.retry else completed)\n",
     "        stmt = f'UPDATE {self} SET \"{status_col}\"=$1 WHERE \"{pk}\"=$2'\n",


### PR DESCRIPTION
This PR ensures the `claim_one` yields before calling `return`, as was previously implemented.

When returning from an`@asynccontextmanager` generator function without yielding, python raises:

```sh
RuntimeError: generator didn't yield
```